### PR TITLE
Fix `GetEnv.fetch("KEY", nil)`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               --out ~/rspec/rspec.xml
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.0
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -58,7 +58,7 @@ workflows:
           matrix:
             alias: old-ruby
             parameters:
-              ruby: ["2.7.7", "3.0.5", "3.1.3"]
+              ruby: ["2.7.8", "3.0.6", "3.1.4"]
           filters:
             tags:
               only:
@@ -66,7 +66,7 @@ workflows:
           context:
             - DockerHub
       - test:
-          ruby: "3.2.0"
+          ruby: "3.2.2"
           filters:
             tags:
               only:

--- a/lib/get_env.rb
+++ b/lib/get_env.rb
@@ -18,13 +18,27 @@ module GetEnv
     ENV[key]
   end
 
-  def self.fetch(key, default = nil)
+  def self.fetch(*args, &block)
+    case args
+    in [key, default] then fetch_with_default(key, default)
+    in [key] then fetch_without_default(key, &block)
+    else raise ArgumentError
+    end
+  end
+
+  def self.fetch_with_default(key, default)
     if ENV.has_key?(key)
       self[key]
-    elsif !default.nil?
+    else
       default
+    end
+  end
+
+  def self.fetch_without_default(key, &block)
+    if ENV.has_key?(key)
+      self[key]
     elsif block_given?
-      yield
+      block.call
     else
       ENV.fetch(key) # Will raise a KeyError
     end

--- a/lib/get_env.rb
+++ b/lib/get_env.rb
@@ -3,44 +3,48 @@
 require 'get_env/version'
 
 module GetEnv
-  def self.[](key)
-    return nil if key.nil?
+  class << self
+    def [](key)
+      return nil if key.nil?
 
-    v = ENV[key].to_i
-    return v if v.to_s == ENV[key]
+      v = ENV[key].to_i
+      return v if v.to_s == ENV[key]
 
-    v = ENV[key].to_f
-    return v if v.to_s == ENV[key]
+      v = ENV[key].to_f
+      return v if v.to_s == ENV[key]
 
-    return false if ENV[key] == 'false'
-    return true if ENV[key] == 'true'
+      return false if ENV[key] == 'false'
+      return true if ENV[key] == 'true'
 
-    ENV[key]
-  end
-
-  def self.fetch(*args, &block)
-    case args
-    in [key, default] then fetch_with_default(key, default)
-    in [key] then fetch_without_default(key, &block)
-    else raise ArgumentError
+      ENV[key]
     end
-  end
 
-  def self.fetch_with_default(key, default)
-    if ENV.has_key?(key)
-      self[key]
-    else
-      default
+    def fetch(*args, &block)
+      case args
+      in [key, default] then fetch_with_default(key, default)
+      in [key] then fetch_without_default(key, &block)
+      else raise ArgumentError
+      end
     end
-  end
 
-  def self.fetch_without_default(key, &block)
-    if ENV.has_key?(key)
-      self[key]
-    elsif block_given?
-      block.call
-    else
-      ENV.fetch(key) # Will raise a KeyError
+    private
+
+    def fetch_with_default(key, default)
+      if ENV.has_key?(key)
+        self[key]
+      else
+        default
+      end
+    end
+
+    def fetch_without_default(key, &block)
+      if ENV.has_key?(key)
+        self[key]
+      elsif block_given?
+        block.call
+      else
+        ENV.fetch(key) # Will raise a KeyError
+      end
     end
   end
 end

--- a/lib/get_env/version.rb
+++ b/lib/get_env/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetEnv
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/get_env_spec.rb
+++ b/spec/get_env_spec.rb
@@ -53,6 +53,10 @@ RSpec.describe GetEnv do
       expect(GetEnv.fetch('SOME_NON_EXISTANT_FLOAT', 3.21)).to eq(3.21)
     end
 
+    it 'allows nil as a default value' do
+      expect(GetEnv.fetch('SOME_NON_EXISTANT_FLOAT', nil)).to be_nil
+    end
+
     it 'raises an exception if not found and no default is specified' do
       expect do
         GetEnv.fetch('SOME_NON_EXISTANT_FLOAT')
@@ -62,6 +66,11 @@ RSpec.describe GetEnv do
     it 'accepts a block for the default value' do
       v = GetEnv.fetch('SOME_NON_EXISTANT_FLOAT') { 3.21 }
       expect(v).to eq(3.21)
+    end
+
+    it 'raises when given too few or too many arguments' do
+      expect { GetEnv.fetch }.to raise_error(ArgumentError)
+      expect { GetEnv.fetch('FOO', 1, 2) }.to raise_error(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
This is currently broken because `nil` is used as a sentinel value to mean that no default value has been given. Since Ruby does not support method overloading, the workaround is to use a splat and pattern match on that. Pattern matching was introduced in Ruby 2.7, which is the oldest supported version.