### PR TITLE
Update Ruby and gems to fix deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
               --out ~/rspec/rspec.xml
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.4.1
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -58,7 +58,7 @@ workflows:
           matrix:
             alias: old-ruby
             parameters:
-              ruby: ["2.7.8", "3.0.6", "3.1.4"]
+              ruby: ["3.0.7", "3.1.6", "3.2.6", "3.3.7"]
           filters:
             tags:
               only:
@@ -66,7 +66,7 @@ workflows:
           context:
             - DockerHub
       - test:
-          ruby: "3.2.2"
+          ruby: "3.4.1"
           filters:
             tags:
               only:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,3 @@ updates:
     interval: daily
     time: "13:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: rubocop
-    versions:
-    - 1.10.0
-    - 1.11.0
-    - 1.12.0
-    - 1.12.1
-    - 1.9.0
-    - 1.9.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,54 @@
 PATH
   remote: .
   specs:
-    get_env (0.2.0)
+    get_env (0.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    diff-lcs (1.5.0)
-    json (2.6.3)
-    parallel (1.22.1)
-    parser (3.2.1.0)
+    diff-lcs (1.5.1)
+    json (2.9.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.26.3)
+    parser (3.3.7.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.7.0)
-    rexml (3.2.5)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rake (13.2.1)
+    regexp_parser (2.10.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.2)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.2)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.46.0)
+    rubocop (1.70.0)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.26.0)
-      parser (>= 3.2.1.0)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.4.2)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -58,4 +62,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.32
+   2.6.3

--- a/lib/get_env/version.rb
+++ b/lib/get_env/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetEnv
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/rubocop/cop/lint/no_env.rb
+++ b/lib/rubocop/cop/lint/no_env.rb
@@ -15,7 +15,9 @@ module RuboCop
       #
       #   # good
       #   GetEnv.fetch(...)
-      class NoENV < Cop
+      class NoENV < Base
+        extend AutoCorrector
+
         MSG = 'Use `GetEnv` instead of `ENV`.'
 
         def_node_matcher :is_ENV_index?, '(send (const nil? :ENV) :[] _key)'
@@ -25,11 +27,7 @@ module RuboCop
           parent = node.parent
           return unless is_ENV_index?(parent) || is_ENV_fetch?(parent)
 
-          add_offense(node)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node) do |corrector|
             if Gem::Version.new(RuboCop::Version.version) >= Gem::Version.new('0.82.0')
               corrector.replace(node, 'GetEnv')
             else

--- a/spec/rubocop/cop/lint/no_env_spec.rb
+++ b/spec/rubocop/cop/lint/no_env_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::NoENV do
     it 'registers an offense when using `ENV`' do
       expect_offense(<<~RUBY)
         FOO = ENV['FOO']
-              ^^^ Use `GetEnv` instead of `ENV`.
+              ^^^ Lint/NoENV: Use `GetEnv` instead of `ENV`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::Lint::NoENV do
     it 'registers an offense when using `ENV`' do
       expect_offense(<<~RUBY)
         do_the_thing(ENV.fetch('FOO'))
-                     ^^^ Use `GetEnv` instead of `ENV`.
+                     ^^^ Lint/NoENV: Use `GetEnv` instead of `ENV`.
       RUBY
 
       expect_correction(<<~RUBY)
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::Lint::NoENV do
     it 'registers an offense when using `ENV` with a default value' do
       expect_offense(<<~RUBY)
         a = x + ENV.fetch('FOO', 42)
-                ^^^ Use `GetEnv` instead of `ENV`.
+                ^^^ Lint/NoENV: Use `GetEnv` instead of `ENV`.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
Deprecation warning said:
```
rubocop/cop/lint/no_env.rb:18: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```

Also upgraded all gems dependencies to their latest version.