### PR TITLE
Fix push_to_rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
               --out ~/rspec/rspec.xml
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.4.1
+      # Push to rubygems breaks with Ruby > 3.2
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN


### PR DESCRIPTION
Same happened for some other repos, and quickest solution is to fix the ruby version for the `push_to_rubygems` job
https://github.com/rainforestapp/rf-stylez/pull/228/files

