### PR TITLE
Fix pushing to rubygems with newer ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ jobs:
               --out ~/rspec/rspec.xml
   push_to_rubygems:
     docker:
-      # Push to rubygems breaks with Ruby > 3.2
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.4.1
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -43,7 +42,7 @@ jobs:
           command: |
             mkdir ~/.gem
             echo "---
-              :rubygems_api_key: $RUBYGEMS_API_KEY
+            :rubygems_api_key: $RUBYGEMS_API_KEY
             " > ~/.gem/credentials
             chmod 600 ~/.gem/credentials
       - run:

--- a/lib/get_env/version.rb
+++ b/lib/get_env/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetEnv
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
The issue is with the parsing of the credentials file, because we have some extra spaces in it that the new ruby yaml parser doesn't care for. Leading spaces also seem like invalid yaml to me, so this is more correct anyway.

```
irb(main):001> require 'rubygems/yaml_serializer'
=> true

# No leading spaces before the rubygems api key
irb(main):002> f = File.read('credentials')
=> "---\n:rubygems_api_key: \n\n"
irb(main):003> Gem::YAMLSerializer.load(f)
=> {":rubygems_api_key"=>{}}

# With leading spaces before the :rubygems_api_key
irb(main):006> f = File.read('credentials')
=> "---\n  :rubygems_api_key: \n\n"
irb(main):007> Gem::YAMLSerializer.load(f)
ruby/3.3.0/rubygems/yaml_serializer.rb:66:in `block in load': undefined method `[]=' for nil (NoMethodError)
```